### PR TITLE
Now works with even-ID motor drives! Fixes issue #1

### DIFF
--- a/xiaomi_cybergear/xiaomi_cybergear_driver.cpp
+++ b/xiaomi_cybergear/xiaomi_cybergear_driver.cpp
@@ -197,7 +197,7 @@ void XiaomiCyberGearDriver::_send_can_package(uint8_t can_id, uint8_t cmd_id, ui
     uint32_t id = cmd_id << 24 | option << 8 | can_id;
 
     twai_message_t message;
-    message.extd = id;
+    message.extd = 1; //enable extended frame format
     message.identifier = id;
     message.data_length_code = len;
     for (int i = 0; i < len; i++) {


### PR DESCRIPTION
Took some serious debugging to fix this but super happy to have it all working well now 😅

Fixes my own issue over at https://github.com/DanielKalicki/Xiaomi_CyberGear_Arduino/issues/1

Thanks for the nice library!

- twai_message_t.extd is a 1-bit member that sets a union
- extd needs to be set to 1, not the ID value